### PR TITLE
Rename velocity command, update gradle, and allow for 1.18+

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Sep 03 21:49:49 EDT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/net/kyrptonaught/velocitycommand/VelocityCommand.java
+++ b/src/main/java/net/kyrptonaught/velocitycommand/VelocityCommand.java
@@ -14,7 +14,7 @@ import java.util.Collection;
 public class VelocityCommand {
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        dispatcher.register(CommandManager.literal("velocity")
+        dispatcher.register(CommandManager.literal("setvelocity")
                 .requires((source) -> source.hasPermissionLevel(2))
                 .then(CommandManager.argument("entity", EntityArgumentType.entities())
                         .then(CommandManager.literal("add")

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": "1.17.x",
+    "minecraft": ">=1.17",
     "java": ">=16"
   }
 }


### PR DESCRIPTION
`/velocity` is now `/setvelocity` (this was to account for [velocitypowered](https://velocitypowered.com/) adding a `/velocity` command)
gradle is updated from 7.0.2 to 7.4